### PR TITLE
simpledb route53

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Build and install project-generator and generator-maven-plugin
-mvn clean install
+mvn clean install deploy
 
 # Run the project generator
 pushd project-generator
@@ -21,5 +21,5 @@ popd
 
 # Build and install the project
 pushd project
-mvn clean install
+mvn clean install deploy
 popd

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 parentPomVersion: 0.0.2-SNAPSHOT
-sdkVersion: 1.10.64
+sdkVersion: 1.11.15
 modules:
  -
   name: cloudwatch
@@ -34,10 +34,19 @@ modules:
   classPrefix: AmazonMachineLearning
   serviceName: Amazon Machine Learning
  -
+  name: route53
+  classPrefix: AmazonRoute53
+  serviceName: Route53
+ -
   name: ses
   package: simpleemail
   classPrefix: AmazonSimpleEmailService
   serviceName: Simple Email Service
+ -
+  name: simpledb
+  classPrefix: AmazonSimpleDB
+  serviceName: SimpleDB
+  shutdownSupported: false
  -
   name: sns
   classPrefix: AmazonSNS

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 parentPomVersion: 0.0.2-SNAPSHOT
-sdkVersion: 1.10.14
+sdkVersion: 1.10.60
 modules:
  -
   name: cloudwatch
@@ -15,6 +15,10 @@ modules:
   name: ecs
   classPrefix: AmazonECS
   serviceName: EC2 Container Service
+ -
+  name: iam
+  package: identitymanagement
+  classPrefix: AmazonIdentityManagement
  -
   name: kinesis
   classPrefix: AmazonKinesis
@@ -37,7 +41,7 @@ modules:
  -
   name: sns
   classPrefix: AmazonSNS
-  serviceName: Simple Queue Service
+  serviceName: Simple Notification Service
  -
   name: sqs
   classPrefix: AmazonSQS

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 parentPomVersion: 0.0.2-SNAPSHOT
-sdkVersion: 1.10.60
+sdkVersion: 1.10.64
 modules:
  -
   name: cloudwatch

--- a/generator-maven-plugin/src/main/java/com/amazonaws/generator/scala/ClientModel.java
+++ b/generator-maven-plugin/src/main/java/com/amazonaws/generator/scala/ClientModel.java
@@ -40,6 +40,7 @@ public final class ClientModel {
 
     private final String pkg;
     private final String classPrefix;
+    private final boolean shutdownSupported;
     private final List<OperationModel> operations;
 
     /**
@@ -48,10 +49,11 @@ public final class ClientModel {
      * @param classPrefix the initial part of the class name (ie 'AmazonKinesis'
      *            for 'AmazonKinesisClientAsync')
      */
-    public ClientModel(String pkg, String classPrefix) {
+    public ClientModel(String pkg, String classPrefix, boolean shutdownSupported) {
 
         this.pkg = pkg;
         this.classPrefix = classPrefix;
+        this.shutdownSupported = shutdownSupported;
 
         String name = String.format(
                 "com.amazonaws.services.%s.%sAsync",
@@ -91,6 +93,13 @@ public final class ClientModel {
      */
     public String getClassPrefix() {
         return classPrefix;
+    }
+
+    /**
+     * @return the start of the class name to generate
+     */
+    public boolean isShutdownSupported() {
+        return shutdownSupported;
     }
 
     /**

--- a/generator-maven-plugin/src/main/java/com/amazonaws/generator/scala/GeneratorMojo.java
+++ b/generator-maven-plugin/src/main/java/com/amazonaws/generator/scala/GeneratorMojo.java
@@ -49,6 +49,9 @@ public class GeneratorMojo extends AbstractMojo {
     @Parameter(required = true)
     private String classPrefix;
 
+    @Parameter(required = true)
+    private boolean shutdownSupported;
+
     public GeneratorMojo() {
         freemarker = new Freemarker();
     }
@@ -68,7 +71,7 @@ public class GeneratorMojo extends AbstractMojo {
 
         Template template = freemarker.getClientTemplate();
 
-        ClientModel model = new ClientModel(pkg, classPrefix);
+        ClientModel model = new ClientModel(pkg, classPrefix, shutdownSupported);
 
         String path = String.format(
                 "com/amazonaws/services/%s/scala/%sClient.scala",

--- a/generator-maven-plugin/src/main/resources/templates/scala-client.ftl
+++ b/generator-maven-plugin/src/main/resources/templates/scala-client.ftl
@@ -72,6 +72,8 @@ class ${classPrefix}Client(private val client: ${classPrefix}Async) {
   }
 
 </#list>
+<#if shutdownSupported>
   /** Shuts down this client. */
   def shutdown(): Unit = client.shutdown()
+</#if>
 }

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,19 @@
     </dependencies>
   </dependencyManagement>
 
+  <distributionManagement>
+      <repository>
+          <id>echo360-public-releases</id>
+          <name>Echo360 Public Releases</name>
+          <url>https://artifactory.echo360.net/artifactory/echo360-public-releases</url>
+      </repository>
+      <snapshotRepository>
+          <id>echo360-public-snapshots</id>
+          <name>Echo360 Public Snapshots</name>
+          <url>https://artifactory.echo360.net/artifactory/echo360-public-snapshots</url>
+      </snapshotRepository>
+  </distributionManagement>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/project-generator/src/main/java/com/amazonaws/scala/ModuleModel.java
+++ b/project-generator/src/main/java/com/amazonaws/scala/ModuleModel.java
@@ -25,6 +25,7 @@ public final class ModuleModel {
     private final String classPrefix;
     private final String serviceName;
     private final String pkg;
+    private final String shutdownSupported;
 
     private String sdkVersion;
 
@@ -33,12 +34,14 @@ public final class ModuleModel {
      * @param classPrefix the class prefix (ie 'AmazonKinesis')
      * @param serviceName the (optional) name of the service (ie 'Kinesis')
      * @param pkg the Java package name to use, if different than {@code name}
+     * @param shutdownSupported whether the service supports shutdown, default = true
      */
     public ModuleModel(
             @JsonProperty(value="name", required=true) String name,
             @JsonProperty(value="classPrefix", required=true) String classPrefix,
             @JsonProperty(value="serviceName") String serviceName,
-            @JsonProperty(value="package") String pkg) {
+            @JsonProperty(value="package") String pkg,
+            @JsonProperty(value="shutdownSupported") String shutdownSupported) {
 
         this.name = name;
         this.classPrefix = classPrefix;
@@ -57,6 +60,12 @@ public final class ModuleModel {
             this.pkg = pkg;
         } else {
             this.pkg = name;
+        }
+
+        if (shutdownSupported != null) {
+            this.shutdownSupported = Boolean.valueOf(shutdownSupported).toString();
+        } else {
+            this.shutdownSupported = Boolean.TRUE.toString();
         }
     }
 
@@ -86,6 +95,13 @@ public final class ModuleModel {
      */
     public String getPackage() {
         return pkg;
+    }
+
+    /**
+     * @return whether the services supports the shutdown() method
+     */
+    public String getShutdownSupported() {
+        return shutdownSupported;
     }
 
     /**

--- a/project-generator/src/main/resources/templates/pom.ftl
+++ b/project-generator/src/main/resources/templates/pom.ftl
@@ -33,6 +33,7 @@
         <configuration>
           <pkg>${package}</pkg>
           <classPrefix>${classPrefix}</classPrefix>
+          <shutdownSupported>${shutdownSupported}</shutdownSupported>
         </configuration>
         <dependencies>
           <dependency>


### PR DESCRIPTION
add support for generating client wrappers for AmazonRoute53 and AmazonSimpleDB -- required additional parameter to indicate "shutdown()" method isn't supported by the client being wrapped (for AmazonSimpleDb)

generate wrappers for AWS Java SDK v1.11.15
