### PR TITLE
Fixed naming for AmazonSNS.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -37,7 +37,7 @@ modules:
  -
   name: sns
   classPrefix: AmazonSNS
-  serviceName: Simple Queue Service
+  serviceName: Simple Notification Service
  -
   name: sqs
   classPrefix: AmazonSQS


### PR DESCRIPTION
The service name for AmazonSNS corrected as `Simple Notification Service`.
